### PR TITLE
1-Core-group-should-not-load-iterators-tests

### DIFF
--- a/src/BaselineOfTreeQuery/BaselineOfTreeQuery.class.st
+++ b/src/BaselineOfTreeQuery/BaselineOfTreeQuery.class.st
@@ -16,7 +16,11 @@ BaselineOfTreeQuery >> baseline: spec [
 				package: 'TreeQuery-Tests' with: [ spec requires: #('TreeQuery') ].
 			spec
 				baseline: 'Iterators'
-				with: [ spec repository: 'github://juliendelplanque/Iterators:v1.x.x/src' ].
+				with: [ 
+					spec repository: 'github://juliendelplanque/Iterators:v1.x.x/src';
+						loads: #('core' 'collections' 'shell-dsl' 'inspector-extensions') ];
+				project: 'IteratorsTests' copyFrom: 'Iterators' with: [ spec loads: #('tests') ].
 			spec
-				group: 'core' with: #('TreeQuery') ]
+				group: 'core' with: #('TreeQuery');
+				group: 'tests' with: #('TreeQuery-Tests' 'IteratorsTests') ]
 ]


### PR DESCRIPTION
Created 'core' and 'tests' groups.
Now, 'core' group depends on 'core' group of iterators only.
To get tests, load 'tests' group.Fixes #1